### PR TITLE
Fix code scanning alert no. 3: Regular expression injection

### DIFF
--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -60,7 +60,8 @@
     "@ethereumjs/common": "^4.3.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.0.3",
-    "ethereum-cryptography": "^2.1.3"
+    "ethereum-cryptography": "^2.1.3",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",

--- a/packages/tx/test/transactionRunner.spec.ts
+++ b/packages/tx/test/transactionRunner.spec.ts
@@ -1,6 +1,7 @@
 import { Common } from '@ethereumjs/common'
 import { bytesToHex, toBytes } from '@ethereumjs/util'
 import minimist from 'minimist'
+import _ from 'lodash'
 import { assert, describe, it } from 'vitest'
 
 import { TransactionFactory } from '../src/index.js'
@@ -45,7 +46,7 @@ const EIPs: Record<string, number[] | undefined> = {
 }
 
 describe('TransactionTests', async () => {
-  const fileFilterRegex = file !== undefined ? new RegExp(file + '[^\\w]') : undefined
+  const fileFilterRegex = file !== undefined ? new RegExp(_.escapeRegExp(file) + '[^\\w]') : undefined
   await getTests(
     (
       _filename: string,


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/3](https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/3)

To fix the problem, we need to sanitize the user input before using it to construct the regular expression. The best way to do this is by using the `_.escapeRegExp` function from the lodash library, which escapes special characters in the input string that have special meaning in regular expressions.

1. Import the lodash library.
2. Use the `_.escapeRegExp` function to sanitize the `file` variable before using it in the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Fix regular expression injection vulnerability by sanitizing user input with lodash's escapeRegExp function and update dependencies to include lodash.

Bug Fixes:
- Sanitize user input in regular expression construction to prevent regular expression injection by using lodash's escapeRegExp function.

Enhancements:
- Add lodash as a dependency to utilize its escapeRegExp function for input sanitization.