### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -4,6 +4,9 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   cwd: ${{github.workspace}}/packages/vm
 
@@ -176,6 +179,9 @@ jobs:
 
   vm-benchmarks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/38](https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/38)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for all jobs. Since the workflow primarily performs read-only operations, we will set `contents: read` as the default. For the `vm-benchmarks` job, which uses the `github-action-benchmark@v1` action to comment on commits, we will override the permissions to include `contents: read` and `pull-requests: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add permissions configuration to GitHub workflow to address code scanning alert

CI:
- Added root-level permissions block with read-only access to contents
- Added job-specific permissions for vm-benchmarks job to enable pull request comments