### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/wallet-build.yml
+++ b/.github/workflows/wallet-build.yml
@@ -1,4 +1,6 @@
 name: Wallet
+permissions:
+  contents: read
 on:
   push:
     branches: [master, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/34](https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/34)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the least privileges required. Based on the workflow's steps, it primarily reads repository contents (e.g., for `npm ci`, `npm run lint`, and `npm run test:node`) and uploads coverage reports using the `codecov-action`. Therefore, the minimal permissions required are `contents: read`. No write permissions are necessary for this workflow.

The `permissions` block will be added after the `name` field at the top of the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add `permissions: contents: read` to the Wallet GitHub Actions workflow to resolve the missing permissions code scanning alert.