### PR TITLE
Potential fix for code scanning alert no. 3: Regular expression injection

### DIFF
--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -60,7 +60,8 @@
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.0.2",
-    "ethereum-cryptography": "^2.1.3"
+    "ethereum-cryptography": "^2.1.3",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",

--- a/packages/tx/test/transactionRunner.spec.ts
+++ b/packages/tx/test/transactionRunner.spec.ts
@@ -2,6 +2,7 @@ import { Common } from '@ethereumjs/common'
 import { bytesToHex, toBytes } from '@ethereumjs/util'
 import minimist from 'minimist'
 import { assert, describe, it } from 'vitest'
+import _ from 'lodash'
 
 import { TransactionFactory } from '../src/index.js'
 
@@ -45,7 +46,7 @@ const EIPs: Record<string, number[] | undefined> = {
 }
 
 describe('TransactionTests', async () => {
-  const fileFilterRegex = file !== undefined ? new RegExp(file + '[^\\w]') : undefined
+  const fileFilterRegex = file !== undefined ? new RegExp(_.escapeRegExp(file) + '[^\\w]') : undefined
   await getTests(
     (
       _filename: string,


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/3](https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/3)

To fix the issue, the user input (`file`) should be sanitized before being used in the regular expression. The best approach is to use a library like `lodash` and its `_.escapeRegExp` function to escape any special characters in the input. This ensures that the input is treated as a literal string in the regular expression, preventing injection attacks.

The changes required are:
1. Import the `lodash` library.
2. Use `_.escapeRegExp` to sanitize the `file` variable before constructing the regular expression.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Prevent regex injection by importing `lodash` and escaping the `file` input before using it in the regular expression used for filtering transaction test files.

Bug Fixes:
- Sanitize the user-provided `file` input in `transactionRunner` by escaping regex metacharacters to prevent regular expression injection

Build:
- Add `lodash` as a dependency in the tx package

Tests:
- Update `transactionRunner.spec.ts` to use `_.escapeRegExp` when constructing `fileFilterRegex`