### PR TITLE
fix: changes across two branches master

### DIFF
--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -1,4 +1,6 @@
 name: VM
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -1,8 +1,8 @@
 name: VM
 on:
-  push:
-    branches: [master, develop]
-    tags: ['*']
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 env:
   cwd: ${{github.workspace}}/packages/vm
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-vm-api:
+  vm-api:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,15 +33,19 @@ jobs:
 
       - run: npm run lint
       - run: npm run coverage
-      #     - run: npm run test:API:browser
+      #     - run: npm run test:API:browser -- disabled until we fix browser tests for vitest
 
       - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: vm
 
-  test-vm-state:
+  vm-state:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fork: ['Berlin', 'London', 'Paris', 'Shanghai', 'Cancun']
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,10 +59,62 @@ jobs:
       - run: npm ci
         working-directory: ${{github.workspace}}
 
-      - run: npm run test:state:selectedForks
+      - run: npm run test:state -- --fork=${{ matrix.fork }} --verify-test-amount-alltests
 
-  test-vm-blockchain:
+  vm-state-extended:
+    if: contains(join(github.event.pull_request.labels.*.name, ' '), 'Test all hardforks')
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fork:
+          [
+            'Cancun',
+            'Shanghai',
+            'Paris',
+            'London',
+            'Berlin',
+            'MuirGlacier',
+            'Istanbul',
+            'Petersburg',
+            'Constantinople',
+            'Byzantium',
+            'SpuriousDragon',
+            'TangerineWhistle',
+            'Homestead',
+            'Chainstart',
+          ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - run: npm ci
+        working-directory: ${{github.workspace}}
+
+      - run: npm run test:state -- --fork=${{ matrix.fork }} --verify-test-amount-alltests
+
+  vm-blockchain:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Args to pass to the tester. Note that some have split the slow tests and only
+        # run on forks where applicable (see PR #489 for numbers on these)
+
+        # Tests were split with --dir and --excludeDir to balance execution times below the 9min mark.
+        args:
+          [
+            '--fork=Berlin --verify-test-amount-alltests',
+            '--fork=London --verify-test-amount-alltests',
+            '--fork=Paris --verify-test-amount-alltests',
+            '--fork=Shanghai --verify-test-amount-alltests',
+            '--fork=Cancun --verify-test-amount-alltests',
+          ]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -72,7 +128,51 @@ jobs:
       - run: npm ci
         working-directory: ${{github.workspace}}
 
-      - run: npm run test:blockchain
+      - run: npm run test:blockchain -- ${{ matrix.args }}
+
+  vm-blockchain-extended:
+    if: contains(join(github.event.pull_request.labels.*.name, ' '), 'Test all hardforks')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Args to pass to the tester.
+        args:
+          [
+            '--fork=Chainstart --verify-test-amount-alltests',
+            '--fork=Homestead --verify-test-amount-alltests',
+            '--fork=TangerineWhistle --verify-test-amount-alltests',
+            '--fork=SpuriousDragon --verify-test-amount-alltests',
+            '--fork=Byzantium --verify-test-amount-alltests',
+            '--fork=Constantinople --verify-test-amount-alltests',
+            '--fork=Petersburg --verify-test-amount-alltests',
+            '--fork=Istanbul --verify-test-amount-alltests',
+            '--fork=MuirGlacier --verify-test-amount-alltests',
+            '--fork=Berlin --verify-test-amount-alltests',
+            '--fork=London --verify-test-amount-alltests',
+            '--fork=Paris --verify-test-amount-alltests',
+            '--fork=Shanghai --verify-test-amount-alltests',
+            '--fork=Cancun --verify-test-amount-alltests',
+            '--fork=ByzantiumToConstantinopleFixAt5 --verify-test-amount-alltests',
+            '--fork=EIP158ToByzantiumAt5 --verify-test-amount-alltests',
+            '--fork=FrontierToHomesteadAt5 --verify-test-amount-alltests',
+            '--fork=HomesteadToDaoAt5 --verify-test-amount-alltests',
+            '--fork=HomesteadToEIP150At5 --verify-test-amount-alltests',
+            '--fork=BerlinToLondonAt5 --verify-test-amount-alltests',
+          ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - run: npm ci
+        working-directory: ${{github.workspace}}
+
+      - run: npm run test:blockchain -- ${{ matrix.args }}
 
   vm-benchmarks:
     runs-on: ubuntu-latest
@@ -98,7 +198,6 @@ jobs:
 
       - name: Compare benchmarks
         uses: rhysd/github-action-benchmark@v1
-        if: github.ref == 'refs/heads/master'
         with:
           tool: 'benchmarkjs'
           # Where the output from the benchmark tool is stored
@@ -110,12 +209,8 @@ jobs:
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy to GitHub pages branch automatically (if on master)
-          auto-push: 'true'
-          # Only keep and display the last 30 commits worth of benchmark data
-          max-items-in-chart: 30
-      - name: Fetch repository branch
-        run: |
-            git fetch origin main:main
+          auto-push: 'false'
+
       # Re-apply git stash to prepare for saving back to cache.
       # Avoids exit code 1 by checking if there are changes to be stashed first
       - run: STASH_LIST=`git stash list` && [ ! -z $STASH_LIST ] && git stash apply || echo "No files to stash-apply. Skipping…"

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -60,7 +60,8 @@
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.0.2",
-    "ethereum-cryptography": "^2.1.3"
+    "ethereum-cryptography": "^2.1.3",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",

--- a/packages/tx/test/transactionRunner.spec.ts
+++ b/packages/tx/test/transactionRunner.spec.ts
@@ -2,6 +2,7 @@ import { Common } from '@ethereumjs/common'
 import { bytesToHex, toBytes } from '@ethereumjs/util'
 import minimist from 'minimist'
 import { assert, describe, it } from 'vitest'
+import _ from 'lodash'
 
 import { TransactionFactory } from '../src/index.js'
 
@@ -45,7 +46,7 @@ const EIPs: Record<string, number[] | undefined> = {
 }
 
 describe('TransactionTests', async () => {
-  const fileFilterRegex = file !== undefined ? new RegExp(file + '[^\\w]') : undefined
+  const fileFilterRegex = file !== undefined ? new RegExp(_.escapeRegExp(file) + '[^\\w]') : undefined
   await getTests(
     (
       _filename: string,


### PR DESCRIPTION
## Summary by Sourcery

Revise the VM GitHub Actions workflow to run on pull requests and manual dispatch, restructure and rename jobs, split state and blockchain tests across forks with matrix strategies and conditional extended runs based on a PR label, disable benchmark auto-push and remove branch constraints, add a lodash dependency to the tx package, update the transaction runner test to escape regex input, and remove the Dependabot configuration.

CI:
- Change VM build workflow trigger to pull_request and workflow_dispatch
- Rename and restructure VM workflow jobs (vm-api, vm-state, vm-blockchain)
- Add matrix strategies for state and blockchain tests across forks
- Introduce conditional extended test jobs for all hardforks based on PR labels
- Disable benchmark auto-push and remove branch-specific fetch steps

Tests:
- Escape file names in transactionRunner spec using lodash escapeRegExp

Chores:
- Add lodash dependency to packages/tx
- Remove .github/dependabot.yml