### PR TITLE
Main ci setup

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -1,54 +1,69 @@
 name: Browser
 on:
-  push:
-    branches: [master, develop]
-    tags: ['*']
-  pull_request:
-    types: [opened, reopened, synchronize]
+  workflow_call:
+    inputs:
+      dep-cache-key:
+        required: true
+        type: string
+      submodule-cache-key:
+          required: true
+          type: string
   workflow_dispatch:
+    inputs:
+      dep-cache-key:
+        required: false
+        default: 'none'
+      submodule-cache-key:
+        required: false
+        default: 'none'
 
 env:
   cwd: ${{github.workspace}}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-browser
+  cancel-in-progress: true
 
 jobs:
   test-all-browser:
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        node-version: [18]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      # We clone the repo and submodules if triggered from work-flow dispatch
+      - if: inputs.submodule-cache-key == 'none'
+        uses: actions/checkout@v4
         with:
-          submodules: recursive # necessary for block tests to load ethereum/tests
-          
-      - name: Use Node.js ${{ matrix.node-version }}
+          submodules: recursive
+
+      # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
+      - if: inputs.dep-cache-key != 'none' 
+        uses: actions/cache/restore@v4
+        id: dep-cache
+        with:
+          path: ${{github.workspace}}
+          key: ${{ inputs.dep-cache-key }}
+  
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 20
           cache: 'npm'
 
-      - run: npm ci
+      - name: Install Dependencies (if called from workflow_dispatch)
+        if: steps.dep-cache.outputs.cache-hit != 'true'
+        run: npm ci     
+        working-directory: ${{ github.workspace }}
+
+      - if: inputs.submodule-cache-key != 'none'
+        uses: actions/cache/restore@v4
+        name: Restore ethereum-tests from cache if available
+        id: submodules-cache
+        with:
+          path: ${{github.workspace}}/packages/ethereum-tests
+          key: ${{ inputs.submodule-cache-key }}
+
       - run: npm run install-browser-deps
+      - run: npx playwright install --with-deps
 
-      #     Install playwright dependencies
-      - run: npx playwright install-deps
-
-      - run: npm run test:browser -w=@ethereumjs/rlp
-      - run: npm run test:browser -w=@ethereumjs/util
-      - run: npm run test:browser -w=@ethereumjs/common
-      - run: npm run test:browser -w=@ethereumjs/trie
-      - run: npm run test:browser -w=@ethereumjs/tx
-      - run: npm run test:browser -w=@ethereumjs/block
-      #     No browser tests for devp2p
-      - run: npm run test:browser -w=@ethereumjs/blockchain
-      #     No browser tests for ethash
-      - run: npm run test:browser -w=@ethereumjs/wallet
-      - run: npm run test:browser -w=@ethereumjs/statemanager
-      - run: npm run test:browser -w=@ethereumjs/evm
-#     VM: several tests not passing yet
-#     - run: npm run test:browser -w=@ethereumjs/vm
-
+      - run: npm run test:browser --workspaces --if-present

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,0 +1,51 @@
+# Sample workflow for building and deploying a Jekyll site to GitHub Pages
+name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main-ci-setup"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '37 2 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
## Summary by Sourcery

Set up main CI by overhauling the browser test workflow into a reusable, cache-enabled process and by adding workflows for Jekyll site deployment and automated stale issue/PR management

CI:
- Revise browser.yml to define a reusable workflow with caching, concurrency control, Node.js 20, and consolidated browser test steps
- Add jekyll-gh-pages.yml to build and deploy a Jekyll site to GitHub Pages on pushes to the main-ci-setup branch and manual triggers
- Add stale.yml to automatically mark and close stale issues and pull requests on a scheduled basis