### PR TITLE
Potential fix for code scanning alert no. 997: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -20,6 +20,9 @@ on:
 env:
   cwd: ${{github.workspace}}
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-browser
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/997](https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/997)

The correct way to address this issue is to add a `permissions` block that explicitly limits the capabilities of the `GITHUB_TOKEN` in the workflow. Since this job does not push to repositories, create pull requests, or use privileged actions, the minimal permission it needs is likely `contents: read`. This can be set at the workflow root or at the `test-all-browser` job level. Setting it at the root covers any present or future jobs, ensuring least privilege by default.

The block to add is:

```yaml
permissions:
  contents: read
```

It should be added near the top of the file, after the `name`, `on`, and `env` blocks but before or alongside `concurrency:`. The earlier it appears (so long as it's outside of `jobs:`), the more globally it applies.

No imports or additional definitions are needed. Only the YAML block must be inserted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Restrict GITHUB_TOKEN permissions by adding a permissions block with contents: read to the browser workflow