### PR TITLE
Potential fix for code scanning alert no. 67: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -1,4 +1,6 @@
 name: Tx
+permissions:
+  contents: read
 on:
   push:
     branches: [master, develop]


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/67](https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/67)

To fix this issue, add a `permissions` block with least privilege at the root level of the workflow (just after the `name:` or the `on:` block), or scoped to the `test-tx` job if different jobs have distinct needs. For this workflow, since it primarily checks out code, installs dependencies, runs lint, coverage, and pushes coverage data (to Codecov, not back to GitHub), it only requires read access to repository contents. Thus, set `permissions: contents: read` at the workflow level, which restricts the GITHUB_TOKEN in all jobs unless overridden. 

Edit `.github/workflows/tx-build.yml`:
- Insert the following under the `name: Tx` line (before `on:`):  
  ```yaml
  permissions:
    contents: read
  ```
No method, import, or other code is needed; this is a pure configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add permissions.contents: read at the root of .github/workflows/tx-build.yml to grant only read access to repository contents