### PR TITLE
Potential fix for code scanning alert no. 66: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/statemanager-build.yml
+++ b/.github/workflows/statemanager-build.yml
@@ -7,6 +7,9 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   cwd: ${{github.workspace}}/packages/statemanager
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/66](https://github.com/Dargon789/Ethereumjs-Webserver/security/code-scanning/66)

In general, fix this by explicitly specifying a minimal `permissions:` block for the workflow or job so that `GITHUB_TOKEN` is restricted to the least privileges needed. For CI tasks that only read the repository contents and don’t interact with issues, PRs, or releases, `contents: read` is usually sufficient.

For this specific workflow (`.github/workflows/statemanager-build.yml`), the `test-statemanager` job only checks out the repository, sets up Node, installs dependencies, runs lint and coverage, and invokes `codecov/codecov-action`. None of these require write access to the GitHub API. The safest non-breaking change is to add a top-level `permissions:` block with `contents: read`, which will apply to all jobs (currently just `test-statemanager`). This documents the requirement and prevents the job from gaining write access if repo defaults are permissive or change in the future.

Concretely:
- In `.github/workflows/statemanager-build.yml`, add a new top-level `permissions:` section after the `on:` block (lines 2–8) and before `env:` (line 10).
- Set it to:
  ```yaml
  permissions:
    contents: read
  ```
- No imports or other definitions are needed; this is a pure YAML/workflow configuration change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add a top-level permissions block to the statemanager-build workflow limiting GITHUB_TOKEN to read-only access to repository contents.